### PR TITLE
Use deleteMany instead of deleteOne in MongoStore and update command …

### DIFF
--- a/dist/stores/mongoStore.js
+++ b/dist/stores/mongoStore.js
@@ -69,7 +69,7 @@ export class MongoStore {
      * @returns {boolean} True if a document was deleted, otherwise false.
      */
     async delete(query) {
-        const result = await this.model.deleteOne(query).exec();
+        const result = await this.model.deleteMany(query).exec();
         return result.deletedCount > 0;
     }
 }

--- a/dist/stores/objectStore.js
+++ b/dist/stores/objectStore.js
@@ -66,7 +66,7 @@ export class ObjectStore {
      * @returns {Promise<T>} The found or created object.
      */
     async fetchOneOrCreate(query, data) {
-        const result = this.fetchOne(query);
+        const result = await this.fetchOne(query);
         if (result !== null)
             return result;
         return this.create(data);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cbw2",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "a custom discord.js bot wrapper",
   "license": "GPL-3.0",
   "author": "vyduck",

--- a/src/classes/handlers/command_handler.ts
+++ b/src/classes/handlers/command_handler.ts
@@ -2,7 +2,8 @@ import {
     SlashCommandBuilder,
     MessageFlags,
     ChatInputCommandInteraction,
-    AutocompleteInteraction
+    AutocompleteInteraction,
+    SharedSlashCommand
 } from "discord.js";
 
 import ms from "ms";
@@ -25,7 +26,7 @@ export type ChatInputCallback = (context: ChatInputCommandContext, interaction: 
  * Extends the base Handler class.
  */
 export class CommandHandler extends Handler<ChatInputCallback> {
-    builder: SlashCommandBuilder;
+    builder: SharedSlashCommand;
     description: string;
     category: string;
     cooldown: [number, number];

--- a/src/stores/mongoStore.ts
+++ b/src/stores/mongoStore.ts
@@ -78,7 +78,7 @@ export class MongoStore<T extends object = any> implements Store<T> {
      * @returns {boolean} True if a document was deleted, otherwise false.
      */
     async delete(query: FilterQuery<T>): Promise<boolean>{
-        const result = await this.model.deleteOne(query).exec();
+        const result = await this.model.deleteMany(query).exec();
         return result.deletedCount > 0;
     }    
 }

--- a/src/stores/objectStore.ts
+++ b/src/stores/objectStore.ts
@@ -75,7 +75,7 @@ export class ObjectStore<T extends ObjectWithId = any> implements Store<T> {
      * @returns {Promise<T>} The found or created object.
      */
     async fetchOneOrCreate(query: Partial<T>, data: T): Promise<T> {
-        const result = this.fetchOne(query);
+        const result = await this.fetchOne(query);
         if (result !== null)
             return result;
         return this.create(data);

--- a/types/classes/handlers/command_handler.d.ts
+++ b/types/classes/handlers/command_handler.d.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder, ChatInputCommandInteraction, AutocompleteInteraction } from "discord.js";
+import { SlashCommandBuilder, ChatInputCommandInteraction, AutocompleteInteraction, SharedSlashCommand } from "discord.js";
 import { AutocompleteCommandContext, ChatInputCommandContext } from "../../interfaces/context.js";
 import { Handler } from "./handler.js";
 export type AutocompleteCallback = (context: AutocompleteCommandContext, interaction: AutocompleteInteraction) => Promise<any> | any;
@@ -8,7 +8,7 @@ export type ChatInputCallback = (context: ChatInputCommandContext, interaction: 
  * Extends the base Handler class.
  */
 export declare class CommandHandler extends Handler<ChatInputCallback> {
-    builder: SlashCommandBuilder;
+    builder: SharedSlashCommand;
     description: string;
     category: string;
     cooldown: [number, number];


### PR DESCRIPTION
…handler types

Updated the delete method in MongoStore to use deleteMany instead of deleteOne, allowing multiple documents matching the query to be deleted. Refactors CommandHandler to use SharedSlashCommand for the builder property and updates related type definitions. Bumped package version to 1.5.1.